### PR TITLE
Allow symbolic use with trexp.m

### DIFF
--- a/trexp.m
+++ b/trexp.m
@@ -105,7 +105,7 @@ function T = trexp(S, theta)
         end
         
         % for a zero so(3) return unit matrix, theta not relevant
-        if norm(w) < 10*eps
+        if ~isa(w, 'sym') && norm(w) < 10*eps
             T = eye(3,3);
             return;
         end


### PR DESCRIPTION
Checking the norm(w) <  10*eps on line 108 throws back an error when used with symbolic variables. Add a check not to perform this numerical verification if used with symbolical variables.